### PR TITLE
FFL-239 - Improvements to Product Management with the 'FFL Required' checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Automatic FFL for WooCommerce is a powerful extension designed to simplify the p
 
 - **Simplified Firearms Shipping:** With Automatic FFL for WooCommerce, you can streamline the complex process of shipping firearms to FFL dealers, making it easy to comply with federal regulations.
 
-- **Automatic Detection of Firearm Products:** When a product with the attribute "ffl-required" is added to the cart, the extension will automatically recognize it as a firearm product, prompting the FFL selection process.
+- **Automatic Detection of Firearm Products:** When a product is selected on the product page as _FFL Required_ and is added to the cart, the extension will automatically recognize it as a firearm product, prompting the FFL selection process.
 
 - **FFL Dealer Map:** A map, along with a list, will be displayed to customers at the checkout, showing nearby FFL dealers based on the customer's address, zipcode, or other search criteria.
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -76,6 +76,7 @@ class Plugin {
 		add_action('woocommerce_after_order_notes', array(Checkout::class, 'add_automaticffl_checkout_field'));
 		add_action('woocommerce_checkout_update_order_meta', array(Checkout::class, 'after_checkout_create_order'), 20, 2);
 		add_action('woocommerce_checkout_update_order_meta', array(Checkout::class, 'save_automaticffl_checkout_field_value'));
+		add_action( 'woocommerce_process_product_meta', array($this, 'save_ffl_required'), 10, 3  );
 	}
 
 	/**
@@ -95,6 +96,7 @@ class Plugin {
 		// Do not save shipping address.
 		add_filter( 'woocommerce_checkout_update_customer_data', array( $this, 'maybe_update_customer_data' ), 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', array(Checkout::class, 'automaticffl_custom_fields') );
+		add_filter( 'product_type_options', array($this, 'ffl_required'), 100, 1 );
 	}
 
 	/**
@@ -114,6 +116,24 @@ class Plugin {
 			$boolean = false;
 		}
 		return $boolean;
+	}
+
+	public function ffl_required($product_type_options) {
+		$product_type_options['ffl_required'] = [
+			'id'            => '_ffl_required',
+			'value'			=> get_post_meta( get_the_ID(), 'ffl_required', true),
+			'wrapper_class' => 'show_if_simple show_if_variable show_if_grouped',
+			'label'         => 'FFL Required',
+			'description'   => 'Check this box if the product requires shipment to an FFL dealer',
+			'default'       => 'no',
+		];
+	
+		return $product_type_options;
+	}
+
+	public function save_ffl_required( $id ) {
+		$is_ffl = isset ($_POST['_ffl_required']) && 'on' === $_POST['_ffl_required'] ? 'yes' : 'no';
+		update_post_meta( $id, '_ffl_required', $is_ffl);
 	}
 
 	/**

--- a/includes/helper/class-config.php
+++ b/includes/helper/class-config.php
@@ -15,7 +15,6 @@ class Config {
 	const FFL_STORE_HASH_CONFIG          = 'wc_ffl_store_hash';
 	const FFL_SANDBOX_MODE_CONFIG        = 'wc_ffl_sandbox_mode';
 	const FFL_GOOGLE_MAPS_API_KEY_CONFIG = 'wc_ffl_google_maps_api_key';
-	const FFL_ATTRIBUTE_NAME             = 'pa_ffl-required';
 
 	/** Permanent Settings */
 	const SETTING_GOOGLE_MAPS_URL    = 'https://maps.googleapis.com/maps/api/js';
@@ -49,10 +48,11 @@ class Config {
 		$total_products = count( $cart );
 		$total_ffl      = 0;
 		foreach ( $cart as $product ) {
-			foreach ( $product['data']->get_attributes() as $attribute ) {
-				if ( self::FFL_ATTRIBUTE_NAME === $attribute['name'] ) {
-					$total_ffl++;
-				}
+			$product_id = $product['product_id'];
+			$ffl_required = get_post_meta($product_id, '_ffl_required', true);
+			
+			if ( $ffl_required === 'yes' ) {
+				$total_ffl++;
 			}
 		}
 
@@ -133,10 +133,11 @@ class Config {
 		$total_products = count( $cart );
 		$total_ffl      = 0;
 		foreach ( $cart as $product ) {
-			foreach ( $product['data']->get_attributes() as $attribute ) {
-				if ( self::FFL_ATTRIBUTE_NAME === $attribute['name'] ) {
-					$total_ffl++;
-				}
+			$product_id = $product['product_id'];
+			$ffl_required = get_post_meta($product_id, '_ffl_required', true);
+			
+			if ( $ffl_required === 'yes' ) {
+				$total_ffl++;
 			}
 		}
 

--- a/includes/views/class-cart.php
+++ b/includes/views/class-cart.php
@@ -32,11 +32,12 @@ class Cart {
 		$ffl_products   = array();
 		$total_ffl      = 0;
 		foreach ( $cart as $product ) {
-			foreach ( $product['data']->get_attributes() as $attribute ) {
-				if ( Config::FFL_ATTRIBUTE_NAME === $attribute['name'] ) {
-					$ffl_products[] = $product['product_id'];
-					$total_ffl++;
-				}
+			$product_id = $product['product_id'];
+			$ffl_required = get_post_meta($product_id, '_ffl_required', true);
+			
+			if ( $ffl_required === 'yes' ) {
+				$ffl_products[] = $product_id;
+				$total_ffl++;
 			}
 		}
 

--- a/includes/views/class-checkout.php
+++ b/includes/views/class-checkout.php
@@ -33,10 +33,11 @@ class Checkout {
 		$total_products = count( $cart );
 		$total_ffl      = 0;
 		foreach ( $cart as $product ) {
-			foreach ( $product['data']->get_attributes() as $attribute ) {
-				if ( Config::FFL_ATTRIBUTE_NAME === $attribute['name'] ) {
-					$total_ffl++;
-				}
+			$product_id = $product['product_id'];
+			$ffl_required = get_post_meta($product_id, '_ffl_required', true);
+			
+			if ( $ffl_required === 'yes' ) {
+				$total_ffl++;
 			}
 		}
 


### PR DESCRIPTION
This PR changes the way the products are set to FFL Required, switching from using Products Attributes to Product Meta Data.

The merchant now has a checkbox on the WooCommerce Product Admin Page to select if the product is an FFL Required Product instead of having to add a Custom Attribute to the product.